### PR TITLE
Persistent toolbar position

### DIFF
--- a/lib/rack/insight/public/__insight__/bookmarklet.js
+++ b/lib/rack/insight/public/__insight__/bookmarklet.js
@@ -211,6 +211,7 @@ document.insightEnable = function() {
 document.insightDisable = function() {
   document.eraseCookie('rack-insight_password');
   document.eraseCookie('rack-insight_enabled');
+  document.eraseCookie('rack-insight_position');
   window.location.reload();
 }
 

--- a/lib/rack/insight/public/__insight__/insight.js
+++ b/lib/rack/insight/public/__insight__/insight.js
@@ -106,7 +106,9 @@ jQuery(function($) {
         $.insight.changeRequest($(this).val())
       });
     $('#rack-insight_debug_button').live('click',function(){
-        $('#rack-insight').toggleClass('rack-insight_top').toggleClass('rack-insight_bottom');
+        new_position = ($('#rack-insight').attr('class')== 'rack-insight_top') ? 'bottom' : 'top';
+        document.createCookie('rack-insight_position', new_position);
+        $('#rack-insight').removeClass('rack-insight_top rack-insight_bottom').addClass('rack-insight_' + new_position);
         return false;
       });
     $('#rack-insight_disable_button').live('click',function(){

--- a/lib/rack/insight/views/toolbar.html.erb
+++ b/lib/rack/insight/views/toolbar.html.erb
@@ -13,6 +13,10 @@
 <script>
   $(function($) {
     $.insight.request_id = <%= request_id %>
+    if(document.readCookie('rack-insight_position')) {
+      $('#rack-insight').removeClass('rack-insight_top rack-insight_bottom')
+        .addClass('rack-insight_' + document.readCookie('rack-insight_position'));
+    }
   })
 </script>
 


### PR DESCRIPTION
For many cases we want to persist rack-insight toolbar position. By clicking debug button, this patch will save toolbar position on cookie so next request toolbar will be loaded using saved position. As usual, just click debug button to toggle position.
