### PR TITLE
Call function to toggle bookmarket.

### DIFF
--- a/lib/rack/insight/public/__insight__/bookmarklet.html
+++ b/lib/rack/insight/public/__insight__/bookmarklet.html
@@ -3,7 +3,7 @@
   </head>
   <body>
     <br/><br/><br/>
-    <a href="javascript: (function(){var script=document.createElement('script'); script.src='/__insight__/bookmarklet.js'; document.getElementsByTagName('head')[0].appendChild(script);})()">
+    <a href="javascript: (function(){var script=document.createElement('script'); script.src='/__insight__/bookmarklet.js'; document.getElementsByTagName('head')[0].appendChild(script); document.insightBookmarklet();})()">
       Toggle Rack::Insight
     </a>
   </body>


### PR DESCRIPTION
So I tried your app mentioned in pull request 6, as well as a fresh, minimal Rails 3.2.8 app which I can provide if necessary, and in both cases the bookmarklet (at `/__insight__/bookmarklet.html`) does not give me the password prompt nor toggle the state of the toolbar. Tried with Chrome 23.0.1262.0 dev and Firefox 13.0.1.

In brynary's rack-bug, I can see that this function is called at the end of the bookmarklet js. The corresponding file in rack-insight does not have this call, and I did not see where this call could have been moved to. So here I move it to the bookmarklet link itself, which fixes it for me.
