### PR TITLE
Use debugger gem, for 1.9.3 support.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-insight (0.5.19)
+    rack-insight (0.5.23)
       rack
       sqlite3 (>= 1.3.3)
       uuidtools (>= 2.1.2)
@@ -9,11 +9,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    archive-tar-minitar (0.5.2)
     columnize (0.3.6)
+    debugger (1.2.0)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.1.1)
+      debugger-ruby_core_source (~> 1.1.3)
+    debugger-linecache (1.1.2)
+      debugger-ruby_core_source (>= 1.1.1)
+    debugger-ruby_core_source (1.1.3)
     diff-lcs (1.1.3)
-    linecache19 (0.5.12)
-      ruby_core_source (>= 0.1.4)
     nokogiri (1.5.4)
     rack (1.3.5)
     rack-protection (1.1.4)
@@ -39,19 +43,9 @@ GEM
     rspec-expectations (2.11.2)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.2)
-    ruby-debug-base19 (0.11.25)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
     ruby2ruby (1.2.5)
       ruby_parser (~> 2.0)
       sexp_processor (~> 3.0)
-    ruby_core_source (0.1.5)
-      archive-tar-minitar (>= 0.5.2)
     ruby_parser (2.3.1)
       sexp_processor (~> 3.0)
     sexp_processor (3.2.0)
@@ -71,12 +65,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  debugger
   rack-insight!
   rake
   redcarpet
   reek (>= 1.2.8)
   roodi (>= 2.1.0)
   rspec (>= 2.11.0)
-  ruby-debug19
   sinatra
   webrat

--- a/rack-insight.gemspec
+++ b/rack-insight.gemspec
@@ -34,7 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", ">= 2.11.0"
   s.add_development_dependency "sinatra"
   s.add_development_dependency "webrat"
-  s.add_development_dependency "ruby-debug19"
-
-
+  s.add_development_dependency "debugger"
 end


### PR DESCRIPTION
As far as I know, the ruby-debug19 gem is known to be incompatible with ruby 1.9.3 - the debugger gem should work with 1.9.2 and 1.9.3.
