### PR TITLE
Fix bug with asset pipeline.

### DIFF
--- a/lib/rack/insight/app.rb
+++ b/lib/rack/insight/app.rb
@@ -52,9 +52,9 @@ module Rack::Insight
 
     def call(env)
       @original_request = Rack::Request.new(env)
+      @env = env
+      self.options = @default_options
       if insight_active?
-        @env = env
-        self.options = @default_options
         Rack::Insight.enable
         env["rack-insight.panels"] = []
         @debug_stack.call(env)

--- a/lib/rack/insight/enable-button.rb
+++ b/lib/rack/insight/enable-button.rb
@@ -23,7 +23,9 @@ module Rack::Insight
     def okay_to_modify?(env, response)
       return false unless response.ok?
       req = Rack::Request.new(env)
-      return MIME_TYPES.include?(req.media_type) && !req.xhr?
+      filters = (env['rack-insight.path_filters'] || []).map { |str| %r(^#{str}) }
+      filter = filters.find { |filter| env['REQUEST_PATH'] =~ filter }
+      return MIME_TYPES.include?(req.media_type) && !req.xhr? && !filter
     end
 
     def inject_button(response)


### PR DESCRIPTION
Check path filters before appending button content to request body.

`@env` assign is moved to top (otherwise all default options will not be merged to `env`).
`self.options` assign is moved to top (otherwise no rack-inside options will be found inside `env`).
