### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ stores debugging info over many requests, incuding AJAX requests.
 | version                 |  [![Gem Version](https://badge.fury.io/rb/rack-insight.png)](http://badge.fury.io/rb/rack-insight) |
 | dependencies            |  [![Dependency Status](https://gemnasium.com/pboling/rack-insight.png)](https://gemnasium.com/pboling/rack-insight) |
 | code quality            |  [![Code Climate](https://codeclimate.com/github/pboling/rack-insight.png)](https://codeclimate.com/github/pboling/rack-insight) |
+| inline documenation     |  [![Inline docs](http://inch-pages.github.io/github/pboling/rack-insight.png)](http://inch-pages.github.io/github/pboling/rack-insight) |
 | continuous integration  |  [![Build Status](https://secure.travis-ci.org/pboling/rack-insight.png?branch=master)](https://travis-ci.org/pboling/rack-insight) (Failing due to [a bug(?) in rvm](https://github.com/wayneeseguin/rvm/issues/2619))|
 | test coverage           |  [![Coverage Status](https://coveralls.io/repos/pboling/rack-insight/badge.png)](https://coveralls.io/r/pboling/rack-insight) |
 | homepage                |  [https://github.com/pboling/rack-insight][homepage] |


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/pboling/rack-insight.png)

Your status page for this project is http://inch-pages.github.io/github/pboling/rack-insight
