### PR TITLE
Update docs badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ stores debugging info over many requests, incuding AJAX requests.
 | version                 |  [![Gem Version](https://badge.fury.io/rb/rack-insight.png)](http://badge.fury.io/rb/rack-insight) |
 | dependencies            |  [![Dependency Status](https://gemnasium.com/pboling/rack-insight.png)](https://gemnasium.com/pboling/rack-insight) |
 | code quality            |  [![Code Climate](https://codeclimate.com/github/pboling/rack-insight.png)](https://codeclimate.com/github/pboling/rack-insight) |
-| inline documenation     |  [![Inline docs](http://inch-pages.github.io/github/pboling/rack-insight.png)](http://inch-pages.github.io/github/pboling/rack-insight) |
+| inline documenation     |  [![Inline docs](http://inch-ci.org/github/pboling/rack-insight.png)](http://inch-ci.org/github/pboling/rack-insight) |
 | continuous integration  |  [![Build Status](https://secure.travis-ci.org/pboling/rack-insight.png?branch=master)](https://travis-ci.org/pboling/rack-insight) (Failing due to [a bug(?) in rvm](https://github.com/wayneeseguin/rvm/issues/2619))|
 | test coverage           |  [![Coverage Status](https://coveralls.io/repos/pboling/rack-insight/badge.png)](https://coveralls.io/r/pboling/rack-insight) |
 | homepage                |  [https://github.com/pboling/rack-insight][homepage] |


### PR DESCRIPTION
Update the URL of the docs badge to include it from inch-ci.org instead of inch-pages.github.io (the former being the successor of the Inch Pages project).

[ci skip]
