### PR TITLE
Remove log output when redis isn't loaded

### DIFF
--- a/lib/rack/insight/config.rb
+++ b/lib/rack/insight/config.rb
@@ -2,7 +2,7 @@ require 'logger' # Require the standard Ruby Logger
 begin
   require 'redis'
 rescue LoadError
-  warn "Could not load redis ruby gem. Some features are disabled."
+  nil
 end
 
 module Rack::Insight


### PR DESCRIPTION
d3cfc5a76 introduced a `warn` statement that prints when redis is not available.

This gets printed whenever the rails environment gets loaded (so, `rails s`,
`rails c, `rake`, etc) which is a bit annoying. The output also broke some
specs in a project that was checking the stdout of some of our
scripts.

@pboling suggested there's a better implementation in http://git.io/vfGPX